### PR TITLE
Add commands documentation & arguments

### DIFF
--- a/src/Console/Commands/DbDump.php
+++ b/src/Console/Commands/DbDump.php
@@ -42,6 +42,11 @@ class DbDump extends Command
         $this->dump($connection);
     }
 
+    /**
+     * Delete all database tables
+     *
+     * @param string $connection
+     */
     private function emptyDatabase($connection)
     {
         if ($this->option('empty-database'))

--- a/src/Console/Commands/DbDump.php
+++ b/src/Console/Commands/DbDump.php
@@ -58,11 +58,13 @@ class DbDump extends Command
                 ->getDoctrineSchemaManager()
                 ->listTableNames();
 
-            foreach ($tableNames as $name) {
-                \DB::connection($connection)
-                    ->table($name)
-                    ->delete();
+            \DB::connection($connection)
+                ->statement("SET foreign_key_checks=0");
+            foreach ($tableNames as $table) {
+                \Schema::connection($connection)->drop($table);
             }
+            \DB::connection($connection)
+                ->statement("SET foreign_key_checks=1");
         }
     }
 

--- a/src/Console/Commands/Shell/DumpCommand.php
+++ b/src/Console/Commands/Shell/DumpCommand.php
@@ -12,8 +12,9 @@ interface DumpCommand
      * @param string $host
      * @param string $username
      * @param string $password
+     * @param string $binary
      *
      * @return bool
      */
-    public function execute($dump, $database, $host = null, $username = null, $password = null);
+    public function execute($dump, $database, $host = null, $username = null, $password = null, $binary = null);
 }

--- a/src/Console/Commands/Shell/MysqlDumpCommand.php
+++ b/src/Console/Commands/Shell/MysqlDumpCommand.php
@@ -12,12 +12,14 @@ class MysqlDumpCommand implements DumpCommand
      * @param string $host
      * @param string $username
      * @param string $password
+     * @param string $binary
      *
      * @return bool
      */
-    public function execute($dump, $database, $host = null, $username = null, $password = null)
+    public function execute($dump, $database, $host = null, $username = null, $password = null, $binary = null)
     {
-        $command = "mysqldump -h $host";
+        $binary = is_null($binary) ? 'mysqldump' : $binary;
+        $command = "$binary -h $host";
         $command .= " -u $username";
         $command .= ($password) ? " -p$password" : '';
         $command .= " -c $database";

--- a/src/Console/Commands/Shell/SqliteDumpCommand.php
+++ b/src/Console/Commands/Shell/SqliteDumpCommand.php
@@ -12,12 +12,14 @@ class SqliteDumpCommand implements DumpCommand
      * @param string $host
      * @param string $username
      * @param string $password
+     * @param string $binary
      *
      * @return bool
      */
-    public function execute($dump, $database, $host = null, $username = null, $password = null)
+    public function execute($dump, $database, $host = null, $username = null, $password = null, $binary = null)
     {
-        $command = "sqlite3 $database '.dump'";
+        $binary = is_null($binary) ? 'sqlite3' : $binary;
+        $command = "$binary $database '.dump'";
         $command .= " > $dump";
 
         exec($command, $output, $status);


### PR DESCRIPTION
Add command documentation `php artisan help codeception:dbdump`;
Add option --no-seed : Disable the seed in the dump process;
Add option --seed-class=DatabaseSeeder : Choose the class to seed in your dump (class from database/seeds);
Add option --binary-dump= : Specify the path to mysqldump (only for mysql connection driver) or sqlite3 (only for sqlite connection driver) to make the dump;
